### PR TITLE
feat!: update ACVM to 0.9.0 and target being a generic ACIR-Arkworks conversion layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,6 @@ cfg-if = "1.0.0"
 # which means we need to add config flags for that dependency too
 # not specifying a default sometimes gives an error that "extern location for acvm does not exist" on some imports locally,
 # but it still builds when specifying `marlin_arkworks_backend/[field name]` in the Cargo.toml inside the nargo crate, uncomment to remove extern location errors
-# default = ["bls12_381"]
+default = ["bn254"]
 bn254 = ["acvm/bn254"]
 bls12_381 = ["acvm/bls12_381"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,24 +7,14 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ark-serialize = { version = "0.3.0", default-features = false, features = [
-    "derive",
-] }
-ark-std = { version = "0.3.0", default-features = false }
-ark-ff = { version = "0.3.0", default-features = false }
-ark-bn254 = { version = "0.3.0", default-features = false, features = [
-    "curve",
-] }
-ark-bls12-381 = { version = "0.3.0", default-features = false, features = [
-    "curve",
-] }
-acvm = "0.3.1"
-ark-marlin = { version = "0.3.0", default-features = false }
-ark-poly-commit = { version = "0.3.0", default-features = false }
-ark-poly = { version = "0.3.0", default-features = false }
-ark-relations = { version = "0.3.0", default-features = false }
-blake2 = { version = "0.9", default-features = false }
 cfg-if = "1.0.0"
+
+acvm = "0.9.0"
+
+ark-ff = { version = "0.4.0", default-features = false }
+ark-bn254 = { version = "0.4.0", default-features = false, features = ["curve"], optional = true }
+ark-bls12-381 = { version = "0.4.0", default-features = false, features = ["curve"], optional = true }
+ark-relations = { version = "0.4.0", default-features = false }
 
 [features]
 # XXX: We probably want to use the re-exported field in acir
@@ -32,5 +22,5 @@ cfg-if = "1.0.0"
 # not specifying a default sometimes gives an error that "extern location for acvm does not exist" on some imports locally,
 # but it still builds when specifying `marlin_arkworks_backend/[field name]` in the Cargo.toml inside the nargo crate, uncomment to remove extern location errors
 default = ["bn254"]
-bn254 = ["acvm/bn254"]
-bls12_381 = ["acvm/bls12_381"]
+bn254 = ["acvm/bn254", "dep:ark-bn254"]
+bls12_381 = ["acvm/bls12_381", "dep:ark-bls12-381"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,26 +1,25 @@
 [package]
 name = "arkworks_backend"
 version = "0.1.0"
-authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2018"
+authors = ["The Noir Team <team@noir-lang.org>"]
+edition = "2021"
+rust-version = "1.66"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 cfg-if = "1.0.0"
-
-acvm = "0.9.0"
+acvm = { version = "0.9.0", default-features = false }
 
 ark-ff = { version = "0.4.0", default-features = false }
-ark-bn254 = { version = "0.4.0", default-features = false, features = ["curve"], optional = true }
-ark-bls12-381 = { version = "0.4.0", default-features = false, features = ["curve"], optional = true }
 ark-relations = { version = "0.4.0", default-features = false }
 
+# curves
+ark-bn254 = { version = "0.4.0", default-features = false, features = ["curve"], optional = true }
+ark-bls12-381 = { version = "0.4.0", default-features = false, features = ["curve"], optional = true }
+
 [features]
-# XXX: We probably want to use the re-exported field in acir
-# which means we need to add config flags for that dependency too
-# not specifying a default sometimes gives an error that "extern location for acvm does not exist" on some imports locally,
-# but it still builds when specifying `marlin_arkworks_backend/[field name]` in the Cargo.toml inside the nargo crate, uncomment to remove extern location errors
 default = ["bn254"]
 bn254 = ["acvm/bn254", "dep:ark-bn254"]
 bls12_381 = ["acvm/bls12_381", "dep:ark-bls12-381"]

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use acvm::acir::circuit::PublicInputs;
 use acvm::acir::native_types::Witness;
 use ark_ff::Field;
@@ -9,6 +7,7 @@ use ark_relations::{
         ConstraintSynthesizer, ConstraintSystemRef, LinearCombination, SynthesisError, Variable,
     },
 };
+
 // AcirCircuit and AcirArithGate are structs that arkworks can synthesise.
 //
 // The difference between these structures and the ACIR structure that the compiler uses is the following:
@@ -29,7 +28,7 @@ pub struct AcirCircuit<F: Field> {
     pub(crate) gates: Vec<AcirArithGate<F>>,
     pub(crate) public_inputs: PublicInputs,
     pub(crate) values: Vec<F>,
-    pub(crate) num_variables: usize,
+    // pub(crate) num_variables: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -77,7 +76,7 @@ impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for AcirCircuit<Cons
             for add_term in gate.add_terms {
                 let coeff = add_term.0;
                 let add_var = variables[add_term.1.as_usize()];
-                arith_gate += (coeff, add_var)
+                arith_gate += (coeff, add_var);
             }
 
             // Process constant term

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -35,7 +35,7 @@ pub struct AcirCircuit<F: Field> {
 }
 
 #[derive(Clone, Debug)]
-pub struct AcirArithGate<F: Field> {
+pub(crate) struct AcirArithGate<F: Field> {
     pub(crate) mul_terms: Vec<(F, Witness, Witness)>,
     pub(crate) add_terms: Vec<(F, Witness)>,
     pub(crate) constant_term: F,

--- a/src/concrete_cfg.rs
+++ b/src/concrete_cfg.rs
@@ -1,8 +1,8 @@
 use crate::bridge::{AcirArithGate, AcirCircuit};
 use acvm::FieldElement;
 
-pub type CurveAcir = AcirCircuit<Fr>;
-pub type CurveAcirArithGate = AcirArithGate<Fr>;
+pub(crate) type CurveAcir = AcirCircuit<Fr>;
+pub(crate) type CurveAcirArithGate = AcirArithGate<Fr>;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "bn254")] {
@@ -10,7 +10,7 @@ cfg_if::cfg_if! {
 
         // Converts a FieldElement to a Fr
         // noir_field uses arkworks for bn254
-        pub fn from_fe(fe : FieldElement) -> Fr {
+        pub(crate) fn from_fe(fe : FieldElement) -> Fr {
             fe.into_repr()
         }
     } else if #[cfg(feature = "bls12_381")] {

--- a/src/concrete_cfg.rs
+++ b/src/concrete_cfg.rs
@@ -1,7 +1,7 @@
 use crate::bridge::{AcirArithGate, AcirCircuit};
 use acvm::FieldElement;
 
-pub(crate) type CurveAcir = AcirCircuit<Fr>;
+pub type CurveAcir = AcirCircuit<Fr>;
 pub(crate) type CurveAcirArithGate = AcirArithGate<Fr>;
 
 cfg_if::cfg_if! {

--- a/src/concrete_cfg.rs
+++ b/src/concrete_cfg.rs
@@ -10,7 +10,7 @@ cfg_if::cfg_if! {
 
         // Converts a FieldElement to a Fr
         // noir_field uses arkworks for bn254
-        pub(crate) fn from_fe(fe : FieldElement) -> Fr {
+        pub fn from_fe(fe : FieldElement) -> Fr {
             fe.into_repr()
         }
     } else if #[cfg(feature = "bls12_381")] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,24 +3,25 @@
 #![warn(unreachable_pub)]
 #![warn(clippy::semicolon_if_nothing_returned)]
 
-use acvm::acir::circuit::Circuit;
+use acvm::acir::circuit::{Circuit, Opcode};
 
 pub mod bridge;
 mod concrete_cfg;
-pub use concrete_cfg::{from_fe, Curve, Fr};
-pub mod serialiser;
+mod serializer;
 
-pub fn compute_num_constraints(acir: &Circuit) -> usize {
+pub use concrete_cfg::{from_fe, Curve, CurveAcir, Fr};
+
+pub fn compute_num_constraints(acir: &Circuit) -> u32 {
     let mut num_opcodes = acir.opcodes.len();
 
     for opcode in acir.opcodes.iter() {
         match opcode {
-            acvm::acir::circuit::Opcode::Arithmetic(arith) => {
+            Opcode::Arithmetic(arith) => {
                 // Each multiplication term adds an extra constraint
                 // plus one for the linear combination gate.
                 num_opcodes += arith.num_mul_terms() + 1;
             }
-            acvm::acir::circuit::Opcode::Directive(_) => (),
+            Opcode::Directive(_) => (),
             _ => unreachable!(
                 "currently we do not support non-arithmetic opcodes {:?}",
                 opcode
@@ -28,7 +29,7 @@ pub fn compute_num_constraints(acir: &Circuit) -> usize {
         }
     }
 
-    num_opcodes
+    num_opcodes as u32
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use acvm::acir::circuit::Circuit;
 
 pub mod bridge;
 mod concrete_cfg;
-pub use concrete_cfg::{Curve, Fr};
+pub use concrete_cfg::{from_fe, Curve, Fr};
 pub mod serialiser;
 
 pub fn compute_num_constraints(acir: &Circuit) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,76 +1,25 @@
+#![forbid(unsafe_code)]
+#![warn(unused_crate_dependencies, unused_extern_crates)]
+#![warn(unreachable_pub)]
+#![warn(clippy::semicolon_if_nothing_returned)]
+
 use acvm::acir::circuit::Circuit;
-use acvm::FieldElement;
-use ark_ff::Zero;
-use ark_marlin::{Marlin, Proof};
-use ark_poly::univariate::DensePolynomial;
-use ark_poly_commit::marlin_pc::MarlinKZG10;
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use serialiser::serialise;
 
 pub mod bridge;
 mod concrete_cfg;
 pub use concrete_cfg::{Curve, Fr};
 pub mod serialiser;
 
-type MultiPC = MarlinKZG10<Curve, DensePolynomial<Fr>>;
-type MarlinInst = Marlin<Fr, MultiPC, blake2::Blake2s>;
-type MarlinBn254Proof = Proof<Fr, MultiPC>;
-
-// Creates a proof using the Marlin proving system
-pub fn prove(acir: Circuit, values: Vec<&FieldElement>) -> Vec<u8> {
-    let num_vars = acir.num_vars() as usize;
-    let num_constraints = compute_num_constraints(&acir);
-
-    // The first variable is zero in Noir.
-    // In PLONK there is no Variable::zero
-    let values: Vec<_> = std::iter::once(&FieldElement::zero())
-        .chain(values.into_iter())
-        .copied()
-        .map(|x| x.into_repr())
-        .collect();
-
-    let concrete_circ = serialise(acir, values);
-
-    // XXX: This should not be used in production
-    let rng = &mut ark_std::test_rng();
-
-    let universal_srs = MarlinInst::universal_setup(num_constraints, num_vars, 100, rng).unwrap();
-
-    let (index_pk, _) = MarlinInst::index(&universal_srs, concrete_circ.clone()).unwrap();
-
-    let proof = MarlinInst::prove(&index_pk, concrete_circ, rng).unwrap();
-
-    // Serialise proof
-    let mut bytes = Vec::new();
-    proof.serialize(&mut bytes).unwrap();
-    bytes
-}
-
-pub fn verify(acir: Circuit, proof: &[u8], public_inputs: Vec<FieldElement>) -> bool {
-    let num_vars = acir.num_vars() as usize;
-    let num_constraints = compute_num_constraints(&acir);
-    let concrete_circ = serialise(acir, vec![Fr::zero(); num_vars]);
-
-    let rng = &mut ark_std::test_rng();
-
-    let universal_srs = MarlinInst::universal_setup(num_constraints, num_vars, 100, rng).unwrap();
-
-    let (_, index_vk) = MarlinInst::index(&universal_srs, concrete_circ).unwrap();
-
-    let public_inputs: Vec<_> = public_inputs.into_iter().map(|x| x.into_repr()).collect();
-    let proof = MarlinBn254Proof::deserialize(proof).unwrap();
-    MarlinInst::verify(&index_vk, &public_inputs, &proof, rng).unwrap()
-}
-
-fn compute_num_constraints(acir: &Circuit) -> usize {
-    // each multiplication term adds an extra constraint
+pub fn compute_num_constraints(acir: &Circuit) -> usize {
     let mut num_opcodes = acir.opcodes.len();
 
     for opcode in acir.opcodes.iter() {
         match opcode {
             acvm::acir::circuit::Opcode::Arithmetic(arith) => {
-                num_opcodes += arith.num_mul_terms() + 1
-            } // plus one for the linear combination gate
+                // Each multiplication term adds an extra constraint
+                // plus one for the linear combination gate.
+                num_opcodes += arith.num_mul_terms() + 1;
+            }
             acvm::acir::circuit::Opcode::Directive(_) => (),
             _ => unreachable!(
                 "currently we do not support non-arithmetic opcodes {:?}",
@@ -84,6 +33,8 @@ fn compute_num_constraints(acir: &Circuit) -> usize {
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeSet;
+
     use super::*;
     use acvm::acir::circuit::{Opcode, PublicInputs};
     use acvm::acir::native_types::{Expression, Witness};
@@ -101,18 +52,16 @@ mod test {
             q_c: FieldElement::zero(),
         };
         let opcode = Opcode::Arithmetic(arith);
-        let circ = Circuit {
+        let _circ = Circuit {
             current_witness_index: 2,
             opcodes: vec![opcode],
-            public_inputs: PublicInputs(vec![Witness(1)]),
+            public_parameters: PublicInputs(BTreeSet::from([Witness(1)])),
+            return_values: PublicInputs(BTreeSet::new()),
         };
         let a_val = FieldElement::from(6_i128);
         let b_val = FieldElement::from(6_i128);
-        let values = vec![&a_val, &b_val];
+        let _values = vec![&a_val, &b_val];
 
-        let proof = prove(circ.clone(), values);
-        let ok = verify(circ.clone(), &proof, vec![a_val]);
-
-        assert!(ok)
+        todo!("re-add some meaningful test here");
     }
 }

--- a/src/serialiser.rs
+++ b/src/serialiser.rs
@@ -10,12 +10,12 @@ use acvm::{
 };
 
 /// Converts an ACIR into an ACIR struct that the arkworks backend can consume.
-pub fn serialize(acir: Circuit, witness_map: BTreeMap<Witness, FieldElement>) -> CurveAcir {
+pub fn serialize(acir: &Circuit, witness_map: BTreeMap<Witness, FieldElement>) -> CurveAcir {
     (acir, witness_map).into()
 }
 
-impl From<(Circuit, BTreeMap<Witness, FieldElement>)> for CurveAcir {
-    fn from(circ_val: (Circuit, BTreeMap<Witness, FieldElement>)) -> CurveAcir {
+impl From<(&Circuit, BTreeMap<Witness, FieldElement>)> for CurveAcir {
+    fn from(circ_val: (&Circuit, BTreeMap<Witness, FieldElement>)) -> CurveAcir {
         // Currently non-arithmetic gates are not supported
         // so we extract all of the arithmetic gates only
         let (circuit, witness_map) = circ_val;
@@ -23,9 +23,9 @@ impl From<(Circuit, BTreeMap<Witness, FieldElement>)> for CurveAcir {
         let public_inputs = circuit.public_inputs();
         let arith_gates: Vec<_> = circuit
             .opcodes
-            .into_iter()
+            .iter()
             .filter(|opcode| opcode.is_arithmetic())
-            .map(|opcode| CurveAcirArithGate::from(opcode.arithmetic().unwrap()))
+            .map(|opcode| CurveAcirArithGate::from(opcode.clone().arithmetic().unwrap()))
             .collect();
 
         let values: Vec<Fr> = witness_map.into_values().map(from_fe).collect();

--- a/src/serialiser.rs
+++ b/src/serialiser.rs
@@ -14,6 +14,12 @@ pub fn serialize(acir: &Circuit, witness_map: BTreeMap<Witness, FieldElement>) -
     (acir, witness_map).into()
 }
 
+impl From<&Circuit> for CurveAcir {
+    fn from(circuit: &Circuit) -> CurveAcir {
+        CurveAcir::from((circuit, BTreeMap::new()))
+    }
+}
+
 impl From<(&Circuit, BTreeMap<Witness, FieldElement>)> for CurveAcir {
     fn from(circ_val: (&Circuit, BTreeMap<Witness, FieldElement>)) -> CurveAcir {
         // Currently non-arithmetic gates are not supported

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -9,11 +9,6 @@ use acvm::{
     FieldElement,
 };
 
-/// Converts an ACIR into an ACIR struct that the arkworks backend can consume.
-pub fn serialize(acir: &Circuit, witness_map: BTreeMap<Witness, FieldElement>) -> CurveAcir {
-    (acir, witness_map).into()
-}
-
 impl From<&Circuit> for CurveAcir {
     fn from(circuit: &Circuit) -> CurveAcir {
         CurveAcir::from((circuit, BTreeMap::new()))


### PR DESCRIPTION
This PR updates to target ACVM 0.9.0 and removes all the broken marlin code (as this requires upstream to migrate to 0.4.0.